### PR TITLE
Admin logout

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -18,4 +18,9 @@ class Admin::SessionsController < ApplicationController
       flash[:incorrect_credentials] = "Incorrect Credentials."
     end
   end
+
+  def destroy
+    session.destroy
+    redirect_to "/"
+  end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -9,13 +9,17 @@ class Admin::SessionsController < ApplicationController
   end
 
   def create
-    admin = Admin.find_by(email: params[:email])
-    if admin.authenticate(params[:password])
-      session[:admin_id] = admin.id
-      redirect_to "/admin/dashboard"
+    if admin = Admin.find_by(email: params[:email])
+      if admin.authenticate(params[:password])
+        session[:admin_id] = admin.id
+        redirect_to "/admin/dashboard"
+      else
+        redirect_to "/admin/login?bypassed=true"
+        flash[:incorrect_credentials] = "Incorrect Credentials."
+      end
     else
       redirect_to "/admin/login?bypassed=true"
-      flash[:incorrect_credentials] = "Incorrect Credentials."
+      flash[:user_not_found] = "There is no user on file with this email address."
     end
   end
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,10 +1,12 @@
 <h1>Pat yourself on the back for completing the gauntlet that is Admin Authentication! Great job!</h1>
 
 <h1>Current Users:</h1>
-  <% @users.each do |user| %>
-  <div id="user-<%= user.id %>">
-    <h3><%= user.name %></h3>
-    <h3><%= user.email %></h3>
-    <%= button_to "Delete This User", "/admin/users", params: {email: user.email}, method: :delete %>
-  </div>
-  <% end %>
+<% @users.each do |user| %>
+<div id="user-<%= user.id %>">
+  <h3><%= user.name %></h3>
+  <h3><%= user.email %></h3>
+  <%= button_to "Delete This User", "/admin/users", params: {email: user.email}, method: :delete %>
+</div>
+<% end %>
+
+<%= button_to "Admin Logout", "/admin/logout", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get "/admin/login", to: "admin/sessions#new"
   post "/admin/login", to: "admin/sessions#create"
+  delete "/admin/logout", to: "admin/sessions#destroy"
 
   delete "/admin/users", to: "admin/users#destroy"
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -53,6 +53,17 @@ describe "admin dashboard page" do
         expect(page).not_to have_content("deletion test2")
         expect(page).not_to have_content("deletion2@test.com")
       end
+
+      it "i see a button to logout, which redirects me to the welcome page and i can no longer access the dashboard", :vcr do
+        click_button "Admin Logout"
+
+        expect(current_path).to eq("/")
+
+        visit "/admin/dashboard"
+
+        expect(current_path).to eq("/admin/security_check")
+        expect(page).to have_content("You must input the site password in order to access the Admin Login page.")
+      end
     end
   end
 

--- a/spec/features/admin/sessions/new_spec.rb
+++ b/spec/features/admin/sessions/new_spec.rb
@@ -18,6 +18,15 @@ describe "/admin/sessions/new page" do
         expect(current_path).to eq("/admin/dashboard")
       end
 
+      it "if i input credentials for an account that does not exist, i am redirected to the admin/login with an error" do
+        fill_in :email, with: "what_the_fuck_did_i_do@bawlmur_po-lice.com"
+        fill_in :password, with: "password123"
+        click_button "Login As Admin"
+
+        expect(current_path).to eq("/admin/login")
+        expect(page).to have_content("There is no user on file with this email address.")
+      end
+
       it "if i input incorect login credentials, i am redirected back to the form with an error message" do
         fill_in :email, with: "just_a_humble_muthafucka@bawlmur_po-lice.com"
         fill_in :password, with: "password12"

--- a/spec/fixtures/vcr_cassettes/admin_dashboard_page/as_a_logged-in_admin/when_i_visit_the_admin_dashboard_page/i_see_a_button_to_logout_which_redirects_me_to_the_welcome_page_and_i_can_no_longer_access_the_dashboard.yml
+++ b/spec/fixtures/vcr_cassettes/admin_dashboard_page/as_a_logged-in_admin/when_i_visit_the_admin_dashboard_page/i_see_a_button_to_logout_which_redirects_me_to_the_welcome_page_and_i_can_no_longer_access_the_dashboard.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/api/v1/users
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"eec55c7ffa34af1c04e5932e1c97c45d"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3b9fbedb-c545-40fb-aab6-13e57e8ae1c1
+      X-Runtime:
+      - '0.117952'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"1","type":"user","attributes":{"name":"Frank","email":"frankhdafgfad@g.com"}},{"id":"2","type":"user","attributes":{"name":"tom","email":"king@g.com"}},{"id":"3","type":"user","attributes":{"name":"nate","email":"nate@g.com"}},{"id":"4","type":"user","attributes":{"name":"bill","email":"bill@g.com"}},{"id":"5","type":"user","attributes":{"name":"timmy","email":"timmy@g.com"}},{"id":"6","type":"user","attributes":{"name":"sue","email":"sue@g.com"}},{"id":"7","type":"user","attributes":{"name":"Example
+        User","email":"example@example.com"}}]}'
+  recorded_at: Thu, 09 Jun 2022 20:20:45 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
This branch accomplishes the following: 

-adds an "admin logout" button to the `/admin/dashboard` page, which destroys the current admin session and redirects the user to the welcome page
-adds additional sad path handling for the `/admin/login` page so that if the user inputs an email address that is not on file, they are redirected back to the `/admin/login` page and see an error telling them that there is no user on file with that email address